### PR TITLE
Update youtube.py

### DIFF
--- a/youtube.py
+++ b/youtube.py
@@ -57,6 +57,7 @@ def get_comments(video_id):
       videoId=video_id,
       part='snippet,id',
         maxResults=50,
+        textFormat='plainText' #prevents getting empty strings for textDisplay (the actual comment) 
         pageToken=next_page_token
     ).execute()
     


### PR DESCRIPTION
workaround to prevent getting empty string for TextDisplay (the actual comment)

reference:
https://code.google.com/p/gdata-issues/issues/detail?id=7978
